### PR TITLE
Feature/download dir from repo

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Download components from a separate directory of a repository, not to clone all repository 
+- Add repository url parser to get information from GitHub repository link
 - Add installation of kb/ps/interface components to the relevant directories
 - Add quiet installation mode
 - Add SCn documentation
@@ -41,5 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove svn dependency
 - Remove trunk folder when download git repository
 - Remove storage parser

--- a/kb/specifications.scs
+++ b/kb/specifications.scs
@@ -21,6 +21,57 @@ sc_component_manager_repository
            					*);;
            			*);;
            	*);;
+        *);
+	-> part_methods_tools_spec
+	    (*
+           	<- concept_reusable_component_specification;;
+           	=> nrel_alternative_addresses:
+           	...
+           	(*
+           		<- sc_node_tuple;;
+           		-> rrel_1:
+           			...
+           			(*
+           				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_methods_tools]
+           					(*
+           						<- concept_github_url;;
+           					*);;
+           			*);;
+           	*);;
+        *);
+	-> part_platform_spec
+	    (*
+           	<- concept_reusable_component_specification;;
+           	=> nrel_alternative_addresses:
+           	...
+           	(*
+           		<- sc_node_tuple;;
+           		-> rrel_1:
+           			...
+           			(*
+           				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_platform/subdir_platform]
+           					(*
+           						<- concept_github_url;;
+           					*);;
+           			*);;
+           	*);;
+        *);
+	-> part_ui_spec
+	    (*
+           	<- concept_reusable_component_specification;;
+           	=> nrel_alternative_addresses:
+           	...
+           	(*
+           		<- sc_node_tuple;;
+           		-> rrel_1:
+           			...
+           			(*
+           				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_ui]
+           					(*
+           						<- concept_github_url;;
+           					*);;
+           			*);;
+           	*);;
         *);;
 
 ..repositories_addresses

--- a/src/manager/commands/constants/command_constants.cpp
+++ b/src/manager/commands/constants/command_constants.cpp
@@ -13,8 +13,10 @@ std::string const GitHubConstants::GIT_CLONE = "git clone";
 std::string const GitHubConstants::RAW_GITHUB_PREFIX = "https://raw.githubusercontent.com/";
 std::string const GitHubConstants::GITHUB_PREFIX = "https://github.com/";
 std::string const GitHubConstants::TREE = "tree";
-std::string const GitHubConstants::CURL_GET_BRANCH_COMMAND = "curl -s -H \"Accept: application/vnd.github.v3+json\" https://api.github.com/repos/";
-std::string const GitHubConstants::GREP_DEFAULT_BRANCH_COMMAND = R"( | grep -w "default_branch" | cut -d ":" -f 2 | tr -d '," ')";
+std::string const GitHubConstants::CURL_GET_BRANCH_COMMAND =
+    "curl -s -H \"Accept: application/vnd.github.v3+json\" https://api.github.com/repos/";
+std::string const GitHubConstants::GREP_DEFAULT_BRANCH_COMMAND =
+    R"( | grep -w "default_branch" | cut -d ":" -f 2 | tr -d '," ')";
 std::string const GitHubConstants::GITHUB_DOWNLOAD_FILE_COMMAND_PREFIX =
     "curl -H 'Accept: application/vnd.github.v3.raw' -o ";
 std::string const GitHubConstants::GITHUB_GET_DEFAULT_BRANCH_COMMAND_PREFIX =

--- a/src/manager/commands/constants/command_constants.cpp
+++ b/src/manager/commands/constants/command_constants.cpp
@@ -7,15 +7,23 @@
 #include "command_constants.hpp"
 
 std::string const SpecificationConstants::SPECIFICATION_FILENAME = "specification.scs";
-std::string const SpecificationConstants::DIRECTORY_DELIMITER = "/";
+char const SpecificationConstants::DIRECTORY_DELIMITER = '/';
 
 std::string const GitHubConstants::GIT_CLONE = "git clone";
 std::string const GitHubConstants::RAW_GITHUB_PREFIX = "https://raw.githubusercontent.com/";
 std::string const GitHubConstants::GITHUB_PREFIX = "https://github.com/";
+std::string const GitHubConstants::TREE = "tree";
+std::string const GitHubConstants::CURL_GET_BRANCH_COMMAND = "curl -s -H \"Accept: application/vnd.github.v3+json\" https://api.github.com/repos/";
+std::string const GitHubConstants::GREP_DEFAULT_BRANCH_COMMAND = R"( | grep -w "default_branch" | cut -d ":" -f 2 | tr -d '," ')";
 std::string const GitHubConstants::GITHUB_DOWNLOAD_FILE_COMMAND_PREFIX =
     "curl -H 'Accept: application/vnd.github.v3.raw' -o ";
 std::string const GitHubConstants::GITHUB_GET_DEFAULT_BRANCH_COMMAND_PREFIX =
     "curl -s -H \"Accept: application/vnd.github.v3+json\" https://api.github.com/repos/";
+std::string const GitHubConstants::FLAG_NO_CHECKOUT = "--no-checkout";
+std::string const GitHubConstants::FLAG_DEPTH = "--depth=";
+std::string const GitHubConstants::FLAG_FILTER_TREE = "--filter=tree:";
+std::string const GitHubConstants::GIT_SPARSE_CHECKOUT = "git sparse-checkout set --no-cone";
+std::string const GitHubConstants::GIT_CHECKOUT = "git checkout";
 
 std::string const GoogleDriveConstants::GOOGLE_DRIVE_PREFIX = "https://drive.google.com/";
 std::string const GoogleDriveConstants::GOOGLE_DRIVE_FILE_PREFIX = "https://drive.google.com/file/d/";

--- a/src/manager/commands/constants/command_constants.hpp
+++ b/src/manager/commands/constants/command_constants.hpp
@@ -12,7 +12,7 @@ class SpecificationConstants
 {
 public:
   static std::string const SPECIFICATION_FILENAME;
-  static std::string const DIRECTORY_DELIMITER;
+  static char const DIRECTORY_DELIMITER;
 };
 
 class GoogleDriveConstants
@@ -28,8 +28,16 @@ class GitHubConstants
 {
 public:
   static std::string const GIT_CLONE;
+  static std::string const FLAG_NO_CHECKOUT;
+  static std::string const FLAG_DEPTH;
+  static std::string const FLAG_FILTER_TREE;
+  static std::string const GIT_SPARSE_CHECKOUT;
+  static std::string const GIT_CHECKOUT;
   static std::string const RAW_GITHUB_PREFIX;
   static std::string const GITHUB_PREFIX;
+  static std::string const TREE;
+  static std::string const CURL_GET_BRANCH_COMMAND;
+  static std::string const GREP_DEFAULT_BRANCH_COMMAND;
   static std::string const GITHUB_DOWNLOAD_FILE_COMMAND_PREFIX;
   static std::string const GITHUB_GET_DEFAULT_BRANCH_COMMAND_PREFIX;
 };

--- a/src/manager/commands/url_parser/repository_url_parser.cpp
+++ b/src/manager/commands/url_parser/repository_url_parser.cpp
@@ -1,0 +1,152 @@
+/*
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
+
+#include "repository_url_parser.hpp"
+
+void RepositoryUrlParser::Parse(std::string const & repositoryUrlAddress)
+{
+  m_urlAddress = repositoryUrlAddress;
+  m_username = ParseUsername();
+  m_repositoryName = ParseRepositoryName();
+  m_branchName = ParseBranchName();
+  m_directoryName = ParseDirectoryName();
+}
+
+// Get username from the url. For example "MksmOrlov" from https://github.com/MksmOrlov/ostis-kb-lib
+std::string RepositoryUrlParser::ParseUsername()
+{
+  std::string username;
+  size_t const usernameRepositoryNamePosition =
+      m_urlAddress.find(GitHubConstants::GITHUB_PREFIX) + GitHubConstants::GITHUB_PREFIX.size();
+  if (usernameRepositoryNamePosition == std::string::npos)
+  {
+    return username;
+  }
+  std::string const componentUsernameRepositoryName = m_urlAddress.substr(usernameRepositoryNamePosition);
+
+  size_t const usernameRepositoryNameDelimiter =
+      componentUsernameRepositoryName.find(SpecificationConstants::DIRECTORY_DELIMITER);
+  if (usernameRepositoryNameDelimiter == std::string::npos)
+  {
+    return username;
+  }
+  username = componentUsernameRepositoryName.substr(0, usernameRepositoryNameDelimiter);
+  return username;
+}
+
+// Get repository name from the url. For example "ostis-kb-lib" from https://github.com/MksmOrlov/ostis-kb-lib
+std::string RepositoryUrlParser::ParseRepositoryName()
+{
+  std::string repositoryName;
+  size_t const usernameStartPosition = m_urlAddress.find(m_username);
+  if (usernameStartPosition == std::string::npos)
+  {
+    return repositoryName;
+  }
+
+  size_t const repositoryNameStartPosition =
+      m_urlAddress.find(SpecificationConstants::DIRECTORY_DELIMITER, usernameStartPosition) + 1;
+  if (repositoryNameStartPosition == std::string::npos || repositoryNameStartPosition == 0)
+  {
+    return repositoryName;
+  }
+  size_t const repositoryNameEndPosition =
+      m_urlAddress.find(SpecificationConstants::DIRECTORY_DELIMITER, repositoryNameStartPosition + 1);
+  m_repositoryUrl = m_urlAddress.substr(0, repositoryNameEndPosition);
+
+  if (repositoryNameEndPosition == std::string::npos)
+  {
+    repositoryName = m_urlAddress.substr(repositoryNameStartPosition);
+  }
+  else
+  {
+    repositoryName =
+        m_urlAddress.substr(repositoryNameStartPosition, repositoryNameEndPosition - repositoryNameStartPosition);
+  }
+
+  return repositoryName;
+}
+
+// Get branch name from the url. For example "main" from
+// https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_methods_tools
+std::string RepositoryUrlParser::ParseBranchName()
+{
+  std::string branchName;
+  size_t const treeStartPosition = m_urlAddress.find(GitHubConstants::TREE);
+  if (treeStartPosition == std::string::npos)
+  {
+    return branchName;
+  }
+
+  size_t const branchNameStartPosition =
+      m_urlAddress.find(SpecificationConstants::DIRECTORY_DELIMITER, treeStartPosition) + 1;
+  if (branchNameStartPosition == std::string::npos || branchNameStartPosition == 0)
+  {
+    return branchName;
+  }
+
+  size_t const branchNameEndPosition =
+      m_urlAddress.find(SpecificationConstants::DIRECTORY_DELIMITER, branchNameStartPosition);
+  if (branchNameEndPosition == std::string::npos || branchNameEndPosition == 0)
+  {
+    return branchName;
+  }
+
+  branchName = m_urlAddress.substr(branchNameStartPosition, branchNameEndPosition - branchNameStartPosition);
+  return branchName;
+}
+
+// Get directory name from the url. For example "part_methods_tools" from
+// https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_methods_tools
+std::string RepositoryUrlParser::ParseDirectoryName()
+{
+  std::string directoryName;
+  size_t const repositoryNameStartPosition = m_urlAddress.find(m_branchName);
+  if (repositoryNameStartPosition == std::string::npos || repositoryNameStartPosition == 0)
+  {
+    return directoryName;
+  }
+
+  size_t const directoryNameStartPosition =
+      m_urlAddress.find(SpecificationConstants::DIRECTORY_DELIMITER, repositoryNameStartPosition) + 1;
+  if (directoryNameStartPosition == std::string::npos || directoryNameStartPosition == 0)
+  {
+    return directoryName;
+  }
+
+  directoryName = m_urlAddress.substr(directoryNameStartPosition);
+  return directoryName;
+}
+
+std::string RepositoryUrlParser::GetUrlAddress()
+{
+  return m_urlAddress;
+}
+
+std::string RepositoryUrlParser::GetUsername()
+{
+  return m_username;
+}
+
+std::string RepositoryUrlParser::GetRepositoryName()
+{
+  return m_repositoryName;
+}
+
+std::string RepositoryUrlParser::GetDirectoryName()
+{
+  return m_directoryName;
+}
+
+std::string RepositoryUrlParser::GetRepositoryUrl()
+{
+  return m_repositoryUrl;
+}
+
+std::string RepositoryUrlParser::GetBranchName()
+{
+  return m_branchName;
+}

--- a/src/manager/commands/url_parser/repository_url_parser.hpp
+++ b/src/manager/commands/url_parser/repository_url_parser.hpp
@@ -1,0 +1,36 @@
+/*
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
+
+#pragma once
+
+#include <string>
+#include "src/manager/commands/constants/command_constants.hpp"
+
+class RepositoryUrlParser
+{
+public:
+  void Parse(std::string const & repositoryUrlAddress);
+
+  std::string GetUrlAddress();
+  std::string GetUsername();
+  std::string GetRepositoryName();
+  std::string GetDirectoryName();
+  std::string GetRepositoryUrl();
+  std::string GetBranchName();
+
+protected:
+  std::string m_urlAddress;
+  std::string m_username;
+  std::string m_repositoryName;
+  std::string m_directoryName;
+  std::string m_repositoryUrl;
+  std::string m_branchName;
+
+  std::string ParseUsername();
+  std::string ParseRepositoryName();
+  std::string ParseDirectoryName();
+  std::string ParseBranchName();
+};

--- a/src/manager/downloader/downloader_git.hpp
+++ b/src/manager/downloader/downloader_git.hpp
@@ -128,9 +128,8 @@ protected:
   static std::string GetDefaultBranch(std::string const & username, std::string const & repositoryName)
   {
     std::stringstream query;
-    query << GitHubConstants::GITHUB_GET_DEFAULT_BRANCH_COMMAND_PREFIX
-          << GitHubConstants::CURL_GET_BRANCH_COMMAND << username
-          << SpecificationConstants::DIRECTORY_DELIMITER << repositoryName
+    query << GitHubConstants::GITHUB_GET_DEFAULT_BRANCH_COMMAND_PREFIX << GitHubConstants::CURL_GET_BRANCH_COMMAND
+          << username << SpecificationConstants::DIRECTORY_DELIMITER << repositoryName
           << GitHubConstants::GREP_DEFAULT_BRANCH_COMMAND;
 
     ScExec exec{{query.str()}};
@@ -172,7 +171,8 @@ protected:
     if (isComponentRepositoryExists)
     {
       std::string existingComponentName;
-      size_t const existingComponentNameStartIndex = downloadPath.size() + repositoryName.size() + 2; // Two '/' symbols
+      size_t const existingComponentNameStartIndex =
+          downloadPath.size() + repositoryName.size() + 2;  // Two '/' symbols
       for (auto const & directory : std::filesystem::directory_iterator(componentPathFromRepo.str()))
       {
         existingComponentName = directory.path().string().substr(existingComponentNameStartIndex);

--- a/tests/units/sc_component_manager_test.hpp
+++ b/tests/units/sc_component_manager_test.hpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-class ScComponentManagerParserTest : public testing::Test
+class ScComponentManagerTest : public testing::Test
 {
 protected:
   void SetUp() override

--- a/tests/units/test_command_parser.cpp
+++ b/tests/units/test_command_parser.cpp
@@ -9,7 +9,7 @@
 #include "sc_component_manager_test.hpp"
 #include "src/manager/commands/sc_component_manager_command.hpp"
 
-TEST_F(ScComponentManagerParserTest, ParseCommandTypes)
+TEST_F(ScComponentManagerTest, ParseCommandTypes)
 {
   std::string commandType;
 
@@ -32,7 +32,7 @@ TEST_F(ScComponentManagerParserTest, ParseCommandTypes)
   EXPECT_EQ(commandType, "install");
 }
 
-TEST_F(ScComponentManagerParserTest, ParseCommandParameters)
+TEST_F(ScComponentManagerTest, ParseCommandParameters)
 {
   std::pair<std::string, CommandParameters> parsed =
       m_commandParser->Parse("components search --class concept_kb_component");
@@ -47,7 +47,7 @@ TEST_F(ScComponentManagerParserTest, ParseCommandParameters)
   EXPECT_EQ(parsed.second.at("r").size(), (size_t)0);
 }
 
-TEST_F(ScComponentManagerParserTest, ParseIncorrectCommands)
+TEST_F(ScComponentManagerTest, ParseIncorrectCommands)
 {
   EXPECT_ANY_THROW(m_commandParser->Parse("components"));
   EXPECT_ANY_THROW(m_commandParser->Parse("foo init"));

--- a/tests/units/test_url_parser.cpp
+++ b/tests/units/test_url_parser.cpp
@@ -1,0 +1,94 @@
+/*
+ * This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+ * Distributed under the MIT License
+ * (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+ */
+
+#include <gtest/gtest.h>
+
+#include "sc_component_manager_test.hpp"
+#include "src/manager/commands/url_parser/repository_url_parser.hpp"
+
+TEST_F(ScComponentManagerTest, ParseRepositoryUrl)
+{
+  std::string const repositoryUrlAddress = "https://github.com/username/repository-name";
+  RepositoryUrlParser parser;
+  parser.Parse(repositoryUrlAddress);
+
+  std::string const urlAddress = parser.GetUrlAddress();
+  std::string const username = parser.GetUsername();
+  std::string const repositoryName = parser.GetRepositoryName();
+  std::string const directoryName = parser.GetDirectoryName();
+  std::string const repositoryUrl = parser.GetRepositoryUrl();
+  std::string const branchName = parser.GetBranchName();
+
+  EXPECT_EQ(urlAddress, repositoryUrlAddress);
+  EXPECT_EQ(username, "username");
+  EXPECT_EQ(repositoryName, "repository-name");
+  EXPECT_EQ(directoryName, "");
+  EXPECT_EQ(repositoryUrl, repositoryUrlAddress);
+  EXPECT_EQ(branchName, "");
+}
+
+TEST_F(ScComponentManagerTest, ParseRepositoryRealUrl)
+{
+  std::string const repositoryUrlAddress = "https://github.com/MksmOrlov/ostis-kb-lib";
+  RepositoryUrlParser parser;
+  parser.Parse(repositoryUrlAddress);
+
+  std::string const urlAddress = parser.GetUrlAddress();
+  std::string const username = parser.GetUsername();
+  std::string const repositoryName = parser.GetRepositoryName();
+  std::string const directoryName = parser.GetDirectoryName();
+  std::string const repositoryUrl = parser.GetRepositoryUrl();
+  std::string const branchName = parser.GetBranchName();
+
+  EXPECT_EQ(urlAddress, repositoryUrlAddress);
+  EXPECT_EQ(username, "MksmOrlov");
+  EXPECT_EQ(repositoryName, "ostis-kb-lib");
+  EXPECT_EQ(directoryName, "");
+  EXPECT_EQ(repositoryUrl, repositoryUrlAddress);
+  EXPECT_EQ(branchName, "");
+}
+
+TEST_F(ScComponentManagerTest, ParseRepositoryUrlWithDirectory)
+{
+  std::string const repositoryUrlAddress = "https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_methods_tools";
+  RepositoryUrlParser parser;
+  parser.Parse(repositoryUrlAddress);
+
+  std::string const urlAddress = parser.GetUrlAddress();
+  std::string const username = parser.GetUsername();
+  std::string const repositoryName = parser.GetRepositoryName();
+  std::string const directoryName = parser.GetDirectoryName();
+  std::string const repositoryUrl = parser.GetRepositoryUrl();
+  std::string const branchName = parser.GetBranchName();
+
+  EXPECT_EQ(urlAddress, repositoryUrlAddress);
+  EXPECT_EQ(username, "MksmOrlov");
+  EXPECT_EQ(repositoryName, "ostis-kb-lib");
+  EXPECT_EQ(directoryName, "part_methods_tools");
+  EXPECT_EQ(branchName, "main");
+  EXPECT_EQ(repositoryUrl, "https://github.com/MksmOrlov/ostis-kb-lib");
+}
+
+TEST_F(ScComponentManagerTest, ParseRepositoryUrlWithSubdirectory)
+{
+  std::string const repositoryUrlAddress = "https://github.com/username/repository-name/tree/main/directory/subdirectory";
+  RepositoryUrlParser parser;
+  parser.Parse(repositoryUrlAddress);
+
+  std::string const urlAddress = parser.GetUrlAddress();
+  std::string const username = parser.GetUsername();
+  std::string const repositoryName = parser.GetRepositoryName();
+  std::string const directoryName = parser.GetDirectoryName();
+  std::string const repositoryUrl = parser.GetRepositoryUrl();
+  std::string const branchName = parser.GetBranchName();
+
+  EXPECT_EQ(urlAddress, repositoryUrlAddress);
+  EXPECT_EQ(username, "username");
+  EXPECT_EQ(repositoryName, "repository-name");
+  EXPECT_EQ(directoryName, "directory/subdirectory");
+  EXPECT_EQ(branchName, "main");
+  EXPECT_EQ(repositoryUrl, "https://github.com/username/repository-name");
+}


### PR DESCRIPTION
To test:
- look at sc-component-manager/kb/specifications.scs and [ostis-kb-lib](https://github.com/MksmOrlov/ostis-kb-lib) repository structure
- build kb & ps
- run manager
- components init (see that all specifications are downloaded correctly, even from subdirectories)
- components search (see that there are all components from specifications)
- components install --idtf part_ui (see that you installed only part_ui component from whole ostis-kb-lib repository)
- components install --idtf part_platfrom (see that you installed part_platfrom component in addition to part_ui from ostis-kb-lib repository. See that installation also works for subdirectories)
- components install --idtf concept_cat (see that installation from whole reposity still works)
- Approve my pull request

* [x] Update changelog if needed
* [x] Update SCn documentation if needed
