### PR TITLE
[feat][commands]: Add commands reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ Possible run flags:
 
 ### Commands
 
-- `components init` or `ci` - download specifications from repositories. `kb/specifications.scs` contains an example of a repository specification.
-- `components search  [--author \<author\>][--class \<class\>][--explanation \<"explanation"\>]` or `cs [--author \<author\>][--class \<class\>][--explanation \<"explanation"\>]` - search a component specification in the knowledge base. You can search components by author, class or explanation substring.
-- `components install [--idtf \<system_idtf\>]` or `cii \<system_idtf\>` - install component by its system identifier.
+- `components init` - download specifications from repositories. `kb/specifications.scs` contains an example of a repository specification.
+  - _Abbreviation_: You can use `ci` or `comp init` instead of `components init`.
+- `components search` with `[--author \<author\>][--class \<class\>][--explanation \<"explanation"\>]` - search a component specification in the knowledge base. You can search components by author, class or explanation substring.
+  - _Abbreviation_: You can use `cs`, `comp search` or `comp s` instead of `components search`.
+- `components install` with ` [--idtf \<system_idtf\>]` - install component by its system identifier.
+  - _Abbreviation_: You can use `cinst` or `comp inst` instead of `components install`.
 
 ## Repository and components
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Possible run flags:
 
 ### Commands
 
-- `components init` - download specifications from repositories. `kb/specifications.scs` contains an example of a repository specification.
-- `components search  [--author \<author\>][--class \<class\>][--explanation \<"explanation"\>]` - search a component specification in the knowledge base. You can search components by author, class or explanation substring.
-- `components install [--idtf \<system_idtf\>]` - install component by its system identifier.
+- `components init` or `ci` - download specifications from repositories. `kb/specifications.scs` contains an example of a repository specification.
+- `components search  [--author \<author\>][--class \<class\>][--explanation \<"explanation"\>]` or `cs [--author \<author\>][--class \<class\>][--explanation \<"explanation"\>]` - search a component specification in the knowledge base. You can search components by author, class or explanation substring.
+- `components install [--idtf \<system_idtf\>]` or `cii \<system_idtf\>` - install component by its system identifier.
 
 ## Repository and components
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add components init command
 - Add storage config and config parser
 - Create base environment to run commands
+- Add commands redaction 
 
 ### Changed
 

--- a/src/manager/command_parser/sc_component_manager_command_parser.hpp
+++ b/src/manager/command_parser/sc_component_manager_command_parser.hpp
@@ -19,11 +19,30 @@ public:
   static std::pair<std::string, CommandParameters> Parse(std::string const & command)
   {
     std::string const COMPONENTS_COMMAND_PREFIX = "components";
+    std::string const COMMAND_COMPONENTS_INIT = "ci";
+    std::string const COMMAND_COMPONENTS_SEARCH = "cs";
+    std::string const COMMAND_COMPONENTS_INSTALL_IDTF = "cii";
     size_t const COMMAND_KEYWORDS_SIZE = 2;
 
     std::pair<std::string, CommandParameters> parsedCommand;
     std::vector<std::string> commandTokens;
     commandTokens = ParseCommand(command);
+
+    if (commandTokens.at(0) == COMMAND_COMPONENTS_INIT)
+      {
+        commandTokens.erase(commandTokens.begin());
+        commandTokens.insert(commandTokens.begin(), {"components","init"});
+      }
+    if (commandTokens.at(0) == COMMAND_COMPONENTS_SEARCH)
+      {
+        commandTokens.erase(commandTokens.begin());
+        commandTokens.insert(commandTokens.begin(), {"components", "search"});
+      }
+    if (commandTokens.at(0) == COMMAND_COMPONENTS_INSTALL_IDTF)
+      {
+        commandTokens.erase(commandTokens.begin());
+        commandTokens.insert(commandTokens.begin(), {"components", "install", "--idtf"});
+      }
 
     if (commandTokens.size() < COMMAND_KEYWORDS_SIZE)
       SC_THROW_EXCEPTION(

--- a/src/manager/command_parser/sc_component_manager_command_parser.hpp
+++ b/src/manager/command_parser/sc_component_manager_command_parser.hpp
@@ -12,6 +12,7 @@
 #include <regex>
 
 #include "../commands/sc_component_manager_command.hpp"
+#include "../commands/constants/command_constants.hpp"
 
 class ScComponentManagerParser
 {
@@ -19,10 +20,6 @@ public:
   static std::pair<std::string, CommandParameters> Parse(std::string const & command)
   {
     std::string const COMPONENTS_COMMAND_PREFIX = "components";
-    static std::vector<std::string> const COMMAND_COMPONENTS_INIT = {"components init", "ci", "comp init"};
-    static std::vector<std::string> const COMMAND_COMPONENTS_SEARCH = {"components search", "cs", "comp search", "comp s"};
-    static std::vector<std::string> const COMMAND_COMPONENTS_INSTALL = {"components install", "cinst","comp inst"};
-    static std::vector<std::vector <std::string>> const COMMAND_LIST = {COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL};
     size_t const COMMAND_KEYWORDS_SIZE = 2;
 
     std::string cutCommand;
@@ -42,14 +39,14 @@ public:
     }
 
     std::string fullCommand = command;
-    for (int indexCommand = 0; indexCommand < COMMAND_LIST.size(); indexCommand++)
+    for (int indexCommand = 0; indexCommand < CommandConstants::COMMAND_LIST.size(); indexCommand++)
     {
-      for (int indexReducedCommand = 1; indexReducedCommand < COMMAND_LIST[indexCommand].size(); indexReducedCommand++)
+      for (int indexReducedCommand = 1; indexReducedCommand < CommandConstants::COMMAND_LIST[indexCommand].size(); indexReducedCommand++)
       {
-        if (cutCommand == COMMAND_LIST[indexCommand][indexReducedCommand])
+        if (cutCommand == CommandConstants::COMMAND_LIST[indexCommand][indexReducedCommand])
         {
-          fullCommand.replace(0, cutCommand.size(), COMMAND_LIST[indexCommand][0]);
-          indexCommand = COMMAND_LIST.size();
+          fullCommand.replace(0, cutCommand.size(), CommandConstants::COMMAND_LIST[indexCommand][0]);
+          indexCommand = CommandConstants::COMMAND_LIST.size();
           break;
         }
       }

--- a/src/manager/command_parser/sc_component_manager_command_parser.hpp
+++ b/src/manager/command_parser/sc_component_manager_command_parser.hpp
@@ -19,31 +19,45 @@ public:
   static std::pair<std::string, CommandParameters> Parse(std::string const & command)
   {
     std::string const COMPONENTS_COMMAND_PREFIX = "components";
-    std::string const COMMAND_COMPONENTS_INIT = "ci";
-    std::string const COMMAND_COMPONENTS_SEARCH = "cs";
-    std::string const COMMAND_COMPONENTS_INSTALL_IDTF = "cii";
+    std::vector<std::string> const COMMAND_COMPONENTS_INIT = {"components init", "ci", "comp init"};
+    std::vector<std::string> const COMMAND_COMPONENTS_SEARCH = {"components search", "cs", "comp search", "comp s"};
+    std::vector<std::string> const COMMAND_COMPONENTS_INSTALL_IDTF = {"components install", "cinst","comp inst"};
+    std::vector<std::vector <std::string>> const COMMAND_LIST = {COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL_IDTF};
     size_t const COMMAND_KEYWORDS_SIZE = 2;
+
+    std::string cutCommand;
+    size_t firstPapameter = command.find('-');
+    if (firstPapameter != std::string::npos)
+    {
+      cutCommand = command.substr(0, firstPapameter - 1);
+    }
+    else 
+    {
+      cutCommand = command;
+    }
+    size_t endOfCommandPos = cutCommand.find_last_not_of(' ');
+    if (endOfCommandPos != std::string::npos) 
+    {
+        cutCommand.erase(endOfCommandPos + 1);
+    }
+
+    std::string fullCommand = command;
+    for (int indexCommand = 0; indexCommand < COMMAND_LIST.size(); indexCommand++)
+    {
+      for (int indexReducedCommand = 1; indexReducedCommand < COMMAND_LIST[indexCommand].size(); indexReducedCommand++)
+      {
+        if (cutCommand == COMMAND_LIST[indexCommand][indexReducedCommand])
+        {
+          fullCommand.replace(0, cutCommand.size(), COMMAND_LIST[indexCommand][0]);
+          break;
+        }
+      }
+    }
 
     std::pair<std::string, CommandParameters> parsedCommand;
     std::vector<std::string> commandTokens;
-    commandTokens = ParseCommand(command);
-
-    if (commandTokens.at(0) == COMMAND_COMPONENTS_INIT)
-      {
-        commandTokens.erase(commandTokens.begin());
-        commandTokens.insert(commandTokens.begin(), {"components","init"});
-      }
-    if (commandTokens.at(0) == COMMAND_COMPONENTS_SEARCH)
-      {
-        commandTokens.erase(commandTokens.begin());
-        commandTokens.insert(commandTokens.begin(), {"components", "search"});
-      }
-    if (commandTokens.at(0) == COMMAND_COMPONENTS_INSTALL_IDTF)
-      {
-        commandTokens.erase(commandTokens.begin());
-        commandTokens.insert(commandTokens.begin(), {"components", "install", "--idtf"});
-      }
-
+    commandTokens = ParseCommand(fullCommand);
+    
     if (commandTokens.size() < COMMAND_KEYWORDS_SIZE)
       SC_THROW_EXCEPTION(
           utils::ExceptionParseError, "Incorrect command. Command type not found in \"" + command + "\"");

--- a/src/manager/command_parser/sc_component_manager_command_parser.hpp
+++ b/src/manager/command_parser/sc_component_manager_command_parser.hpp
@@ -19,7 +19,6 @@ class ScComponentManagerParser
 public:
   static std::pair<std::string, CommandParameters> Parse(std::string const & command)
   {
-    std::string const COMPONENTS_COMMAND_PREFIX = "components";
     size_t const COMMAND_KEYWORDS_SIZE = 2;
 
     std::string cutCommand;
@@ -60,10 +59,10 @@ public:
       SC_THROW_EXCEPTION(
           utils::ExceptionParseError, "Incorrect command. Command type not found in \"" + command + "\"");
 
-    if (commandTokens.at(0) != COMPONENTS_COMMAND_PREFIX)
+    if (commandTokens.at(0) != CommandConstants::COMPONENTS_COMMAND_PREFIX)
       SC_THROW_EXCEPTION(
           utils::ExceptionParseError,
-          "\"" + command + "\" is not a command. Maybe you mean " + COMPONENTS_COMMAND_PREFIX + "?");
+          "\"" + command + "\" is not a command. Maybe you mean " + CommandConstants::COMPONENTS_COMMAND_PREFIX + "?");
 
     parsedCommand.first = commandTokens.at(1);
     CommandParameters commandParameters = GetCommandParameters(commandTokens);

--- a/src/manager/command_parser/sc_component_manager_command_parser.hpp
+++ b/src/manager/command_parser/sc_component_manager_command_parser.hpp
@@ -21,8 +21,8 @@ public:
     std::string const COMPONENTS_COMMAND_PREFIX = "components";
     std::vector<std::string> const COMMAND_COMPONENTS_INIT = {"components init", "ci", "comp init"};
     std::vector<std::string> const COMMAND_COMPONENTS_SEARCH = {"components search", "cs", "comp search", "comp s"};
-    std::vector<std::string> const COMMAND_COMPONENTS_INSTALL_IDTF = {"components install", "cinst","comp inst"};
-    std::vector<std::vector <std::string>> const COMMAND_LIST = {COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL_IDTF};
+    std::vector<std::string> const COMMAND_COMPONENTS_INSTALL = {"components install", "cinst","comp inst"};
+    std::vector<std::vector <std::string>> const COMMAND_LIST = {COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL};
     size_t const COMMAND_KEYWORDS_SIZE = 2;
 
     std::string cutCommand;
@@ -57,7 +57,7 @@ public:
     std::pair<std::string, CommandParameters> parsedCommand;
     std::vector<std::string> commandTokens;
     commandTokens = ParseCommand(fullCommand);
-    
+
     if (commandTokens.size() < COMMAND_KEYWORDS_SIZE)
       SC_THROW_EXCEPTION(
           utils::ExceptionParseError, "Incorrect command. Command type not found in \"" + command + "\"");

--- a/src/manager/command_parser/sc_component_manager_command_parser.hpp
+++ b/src/manager/command_parser/sc_component_manager_command_parser.hpp
@@ -19,10 +19,10 @@ public:
   static std::pair<std::string, CommandParameters> Parse(std::string const & command)
   {
     std::string const COMPONENTS_COMMAND_PREFIX = "components";
-    std::vector<std::string> const COMMAND_COMPONENTS_INIT = {"components init", "ci", "comp init"};
-    std::vector<std::string> const COMMAND_COMPONENTS_SEARCH = {"components search", "cs", "comp search", "comp s"};
-    std::vector<std::string> const COMMAND_COMPONENTS_INSTALL = {"components install", "cinst","comp inst"};
-    std::vector<std::vector <std::string>> const COMMAND_LIST = {COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL};
+    static std::vector<std::string> const COMMAND_COMPONENTS_INIT = {"components init", "ci", "comp init"};
+    static std::vector<std::string> const COMMAND_COMPONENTS_SEARCH = {"components search", "cs", "comp search", "comp s"};
+    static std::vector<std::string> const COMMAND_COMPONENTS_INSTALL = {"components install", "cinst","comp inst"};
+    static std::vector<std::vector <std::string>> const COMMAND_LIST = {COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL};
     size_t const COMMAND_KEYWORDS_SIZE = 2;
 
     std::string cutCommand;
@@ -49,6 +49,7 @@ public:
         if (cutCommand == COMMAND_LIST[indexCommand][indexReducedCommand])
         {
           fullCommand.replace(0, cutCommand.size(), COMMAND_LIST[indexCommand][0]);
+          indexCommand = COMMAND_LIST.size();
           break;
         }
       }

--- a/src/manager/commands/constants/command_constants.cpp
+++ b/src/manager/commands/constants/command_constants.cpp
@@ -31,3 +31,8 @@ std::string const GoogleDriveConstants::GOOGLE_DRIVE_PREFIX = "https://drive.goo
 std::string const GoogleDriveConstants::GOOGLE_DRIVE_FILE_PREFIX = "https://drive.google.com/file/d/";
 std::string const GoogleDriveConstants::GOOGLE_DRIVE_DOWNLOAD_PREFIX = "https://docs.google.com/uc?export=download&id=";
 std::string const GoogleDriveConstants::GOOGLE_DRIVE_POSTFIX = "/view?usp=sharing";
+
+std::vector<std::string> const CommandConstants::COMMAND_COMPONENTS_INIT = {"components init", "ci", "comp init"};
+std::vector<std::string> const CommandConstants::COMMAND_COMPONENTS_SEARCH = {"components search", "cs", "comp search", "comp s"};
+std::vector<std::string> const CommandConstants::COMMAND_COMPONENTS_INSTALL = {"components install", "cinst","comp inst"};
+std::vector<std::vector <std::string>> const CommandConstants::COMMAND_LIST = {COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL};

--- a/src/manager/commands/constants/command_constants.cpp
+++ b/src/manager/commands/constants/command_constants.cpp
@@ -36,3 +36,4 @@ std::vector<std::string> const CommandConstants::COMMAND_COMPONENTS_INIT = {"com
 std::vector<std::string> const CommandConstants::COMMAND_COMPONENTS_SEARCH = {"components search", "cs", "comp search", "comp s"};
 std::vector<std::string> const CommandConstants::COMMAND_COMPONENTS_INSTALL = {"components install", "cinst","comp inst"};
 std::vector<std::vector <std::string>> const CommandConstants::COMMAND_LIST = {COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL};
+std::string const CommandConstants::COMPONENTS_COMMAND_PREFIX = "components";

--- a/src/manager/commands/constants/command_constants.hpp
+++ b/src/manager/commands/constants/command_constants.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+#include <regex>
 
 class SpecificationConstants
 {
@@ -40,4 +41,13 @@ public:
   static std::string const GREP_DEFAULT_BRANCH_COMMAND;
   static std::string const GITHUB_DOWNLOAD_FILE_COMMAND_PREFIX;
   static std::string const GITHUB_GET_DEFAULT_BRANCH_COMMAND_PREFIX;
+};
+
+class CommandConstants
+{
+public:
+  static std::vector<std::string> const COMMAND_COMPONENTS_INIT;
+  static std::vector<std::string> const COMMAND_COMPONENTS_SEARCH;
+  static std::vector<std::string> const COMMAND_COMPONENTS_INSTALL;
+  static std::vector<std::vector <std::string>> const COMMAND_LIST;
 };

--- a/src/manager/commands/constants/command_constants.hpp
+++ b/src/manager/commands/constants/command_constants.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <string>
-#include <regex>
+#include <vector>
 
 class SpecificationConstants
 {
@@ -50,4 +50,5 @@ public:
   static std::vector<std::string> const COMMAND_COMPONENTS_SEARCH;
   static std::vector<std::string> const COMMAND_COMPONENTS_INSTALL;
   static std::vector<std::vector <std::string>> const COMMAND_LIST;
+  static std::string const COMPONENTS_COMMAND_PREFIX;
 };


### PR DESCRIPTION
You can use these reductions:
ci = comp init = components init
cs = comp  search = comp s = components search
cinst = comp inst = components install 

You can add new reductions to the end of vectors COMMAND_COMPONENTS_INIT, COMMAND_COMPONENTS_SEARCH, COMMAND_COMPONENTS_INSTALL