### PR TITLE
[interface] Include sys/select.h

### DIFF
--- a/src/manager/console-interface/sc_component_manager.cpp
+++ b/src/manager/console-interface/sc_component_manager.cpp
@@ -7,12 +7,13 @@
 #include <string>
 #include <iostream>
 #include <thread>
-#include <csignal>
+
+#include <sys/select.h>
 
 #include "sc_component_manager.hpp"
 
 static constexpr int STD_INPUT = 0;
-static constexpr __suseconds_t WAIT_BETWEEN_SELECT_US = 250000L;
+static constexpr suseconds_t WAIT_BETWEEN_SELECT_US = 250000L;
 
 void ScComponentManager::Run()
 {


### PR DESCRIPTION
* [ ] Update changelog if needed
* [ ] Update SCn documentation if needed

This PR fixes build sc-component-manager on macOS. This [PR](https://github.com/ostis-ai/sc-component-manager/pull/108) checks it